### PR TITLE
Default Price Conversion Class

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'active_support/all'
+require 'barchart'
+require 'barchart/client'
+require 'barchart/version'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require 'irb'
+IRB.start(__FILE__)

--- a/lib/barchart/client.rb
+++ b/lib/barchart/client.rb
@@ -31,6 +31,7 @@ module Barchart
     class << self
       attr_accessor :api_key,
                     :base_url,
+                    :default_price_conversion_class_name,
                     :logger,
                     :price_conversion_class_names,
                     :proxy_url,

--- a/spec/factories/barchart/futures_prices.rb
+++ b/spec/factories/barchart/futures_prices.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :futures_price, class: Hash do
+    skip_create
+
+    transient do
+      contract_month { Barchart::MONTH_CODE_MAP.keys.sample }
+      contract_year { Date.current.year }
+      time_now { Time.now }
+
+      sequence(:commodity_code) { |seq| "Z#{seq}" }
+    end
+
+    close { last_price + Faker::Commerce.price(range: -10..10) }
+    day_code { time_now.day }
+    dollar_volume { 0 }
+    flag { '' }
+    high_price { last_price + Faker::Commerce.price(range: 0..10) }
+    last_price { Faker::Commerce.price }
+    low_price { last_price - Faker::Commerce.price(range: 0..10) }
+    mode { 'I' }
+    name { Faker::Commerce.product_name }
+    net_change { 0 }
+    num_trades { 0 }
+    open_price { last_price + Faker::Commerce.price(range: -10..10) }
+    percent_change { 0 }
+    previous_volume { 0 }
+    server_timestamp { time_now.iso8601 }
+    symbol { "#{contract_month}#{contract_year.to_s[-2, 2]}" }
+    trade_timestamp { time_now.iso8601 }
+    unit_code { -1 }
+    volume { 0 }
+
+    initialize_with do
+      attributes
+        .transform_keys { |key| key.to_s.camelize(:lower) }
+    end
+  end
+end

--- a/spec/lib/barchart/futures_price_spec.rb
+++ b/spec/lib/barchart/futures_price_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'barchart'
+require 'barchart/client'
+
+RSpec.describe Barchart::FuturesPrice do
+  describe '.adjusted_last_price' do
+    context 'when there is no price conversion class for the symbol' do
+      it 'uses the default price conversion class' do
+        # Arrange
+        Barchart::Client.configure do |config|
+          config.default_price_conversion_class_name = 'OriginalPrice'
+          config.price_conversion_class_names = {
+            ZC: 'DivideBy100Price'
+          }
+        end
+        instance = described_class.new(last_price: 100, symbol: 'ZMZ22')
+        # Act
+        result = instance.adjusted_last_price
+        # Assert
+        expect(result).to eq(instance.last_price)
+      end
+    end
+
+    context 'when there is a price conversion class for the symbol' do
+      it 'uses the mapped price conversion class' do
+        # Arrange
+        Barchart::Client.configure do |config|
+          config.default_price_conversion_class_name = 'OriginalPrice'
+          config.price_conversion_class_names = {
+            ZC: 'DivideBy100Price'
+          }
+        end
+        instance = described_class.new(last_price: 100, symbol: 'ZCZ22')
+        # Act
+        result = instance.adjusted_last_price
+        # Assert
+        expect(result).to eq(instance.last_price / 100)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add supoprt for a default price conversion class so we don't have configure every commodity code that uses a default price conversion method.

We also take this opportunity to add some missing futures tests.

Closes #4